### PR TITLE
docs: command to launch gestalt in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ make
 
 Launch (needs golang)
 ```
-go run cmd/gestalt/main.go
+go run cmd/gestalt
 ```
 
 Default listens to 0.0.0.0 port 8080


### PR DESCRIPTION
why: Running `go run cmd/gestalt/main.go` compiles only that single file, which can produce misleading “undefined” symbol errors even though the package builds and tests pass.