### PR TITLE
build(otel): add Darwin/arm64 and additional arch targets to OTel makefile

### DIFF
--- a/otel/GNUmakefile
+++ b/otel/GNUmakefile
@@ -12,5 +12,28 @@ Linux_x86_64: download-otel
 	@./ocb --config builder-config.yaml
 	@mv gestalt-otel ..
 
+Linux_arm64: OS := linux
+Linux_arm64: ARCH := arm64
+Linux_arm64: download-otel
+	$(info Open Telemetry Build)
+	@./ocb --config builder-config.yaml
+	@mv gestalt-otel ..
+
+Linux_aarch64: Linux_arm64
+
+Darwin_x86_64: OS := darwin
+Darwin_x86_64: ARCH := amd64
+Darwin_x86_64: download-otel
+	$(info Open Telemetry Build)
+	@./ocb --config builder-config.yaml
+	@mv gestalt-otel ..
+
+Darwin_arm64: OS := darwin
+Darwin_arm64: ARCH := arm64
+Darwin_arm64: download-otel
+	$(info Open Telemetry Build)
+	@./ocb --config builder-config.yaml
+	@mv gestalt-otel ..
+
 clean:
 	git clean -fd .


### PR DESCRIPTION
- add Darwin_arm64 target so gmake -C otel $(uname -s)_$(uname -m) works on Apple Silicon
- add Darwin_x86_64 and Linux_arm64 targets for broader host support
- add Linux_aarch64 alias to map common Linux arch naming to arm64
